### PR TITLE
Clear up error on "What you need" for RiiConnect24

### DIFF
--- a/_pages/en_US/riiconnect24.txt
+++ b/_pages/en_US/riiconnect24.txt
@@ -29,7 +29,9 @@ These instructions will assume you're using an SD card to install RiiConnect24, 
 * An SD card with at least 128 MB of free space
 * Windows, Linux or Mac computer
 * [IOS Patcher](https://github.com/RiiConnect24/IOS-Patcher/releases)
-* nwc24msg.cfg Patcher [Windows](https://github.com/RiiConnect24/RiiConnect24-Mail-Patcher-Windows/releases) [Linux/Mac](https://github.com/Seriell/RC24-MailPatch-Portable/releases)
+* nwc24msg.cfg Patcher:</br>
+  - [Windows](https://github.com/RiiConnect24/RiiConnect24-Mail-Patcher-Windows/releases)
+  - [Linux/Mac](https://github.com/Seriell/RC24-MailPatch-Portable/releases)
 * [Wii Mod Lite](https://github.com/RiiConnect24/Wii-Mod-Lite/releases)
 * [WiiXplorer](https://sourceforge.net/projects/wiixplorer/files/latest/download)
 


### PR DESCRIPTION
I'm making the very rash assumption here that you use ordinary Markdown for this file, please edit accordingly if that's not the case.
The []() links had a space for some reason. Also I think it looks more professional on separate lines indented like this.