### PR TITLE
Remove uneeded instruction that was confusing people

### DIFF
--- a/_pages/en_US/riitag.txt
+++ b/_pages/en_US/riitag.txt
@@ -53,7 +53,6 @@ The steps to connect RiiTag to your USB Loader depend on what USB Loader you use
 1. Search for `wiinnertag_url` and replace that line with `wiinnertag_url=http://tag.rc24.xyz/wii?game={ID6}&key={KEY}`.
 1. Search for `wiinnertag_key` and replace that line with `wiinnertag_key=<key>`, replacing `<key>` with the key you wrote down in Section 1.
 1. Search for `gamercards_enable` and replace that line with `gamercards_enable=yes`.
-1. Search for `async_network` and replace that line with `async_network=yes`.
 1. Save the modified `wiiflow.ini` file.
 1. You have now set up RiiTag. You can try loading any game now to see if it works correctly.
 


### PR DESCRIPTION
Wiiflow lite enables it by default, this line is not present in a normal wiiflow lite cfg