### PR TITLE
Revert dump-games page to how it was previously

### DIFF
--- a/_pages/en_US/dump-games.md
+++ b/_pages/en_US/dump-games.md
@@ -4,72 +4,11 @@ title: "Dumping Wii/GameCube games"
 
 Want to legally dump a GameCube or a Wii game and play it on your Wii? With this tutorial we will explain how to do it.
 
-If you need help for anything regarding this tutorial, please join [the RiiConnect24 Discord server](https://discord.gg/b4Y7jfD) (recommended) or [e-mail us at support@riiconnect24.net](mailto:support@riiconnect24.net).
-{: .notice--info}
-
-These tutorials will teach you how to legally dump a GameCube/Wii disk. You can dump it to either your SD card/USB drive or to your PC using Wi-Fi or an Ethernet adapter.
-
-Dumping to your SD card or USB Drive is quicker but it will take up space on your SD card. If the space is not available and you do not mind the slow speed of Internet travels, you could dump it to your PC.
-
-## Store it on a USB drive or an SD card
-#### Requirements
-
-* A Wii with an Internet connection
-* An SD card or USB drive with at least 4.7 GB of free space
-* [CleanRip](https://github.com/emukidid/cleanrip/releases/latest)
-
-#### Instructions
-##### Section I - Downloading/Installing
-
-1. Extract CleanRip and put it in the `apps` folder on your SD card or USB drive.
-2. Insert your SD card into your Wii, and launch CleanRip from the Homebrew Channel.
-
-##### Section II - Ripping
-
-1. Select your device that you will be dumping the game to - your USB drive or SD card.
-![Device type](/images/CleanRip/2.png)
-2. On this screen, it asks you if you want to download a file with game checksums so you can verify the dump created is a 1:1 copy of the disc. It's your choice whether to say `Yes` or `No` to download this file.
-![DAT](/images/CleanRip/3.png)
-3. Now insert the game you'd like to dump.
-![DVD](/images/CleanRip/4.png)
-![Initialising Disc](/images/CleanRip/5.png)
-4. Set it as shown on the screen below.
-   - If you know that you are dumping a game that uses a dual layer disc, like `Super Smash Bros. Brawl` or `Metroid: Other M`, set `Dual Layer` to `Yes`.
-![Settings](/images/CleanRip/6.png)
-5. CleanRip will now dump your game. It can take a while, since it will dump the full 4.7GB disc contents (9.4 for dual layer discs).
-![Copying](/images/CleanRip/7.png)
-
-## Store it on your PC
-#### What you need
-
-* A Wii.
-* [DVD Dump Tool](/assets/files/DVDDumpTool.zip)
-
-Your Wii and your computer must be connected to one local network
+Please choose how you want to dump the disc.
 {: .notice--warning}
 
-#### Instructions
-##### Section I - Downloading/Installing
+[I want to dump it to the SD card/USB device](cleanrip)
+{: .notice--info}
 
-1. Extract DVD Dump Tool and put it in the `apps` folder on your SD card or USB drive.
-2. Insert your SD card into your Wii, and launch DVD Dump Tool from the Homebrew Channel.
-
-##### Section II - Ripping
-
-1. Press the right button on the d-pad and press "A"
-![2](/images/DumpDiscs_LAN/2.png)
-2. Choose the disc that you want to copy (The options are: `GameCube Disc`, `Wii Single-Layer Disc`, `Wii Dual-Layer Disc` and press "A"
-![3](/images/DumpDiscs_LAN/3.png)
-3. Now put your game to your Wii. (If it's already in your wii, eject it and put it back)
-![InsertTheDisc](/images/DumpDiscs_LAN/insertthedisc.jpg)
-![4](/images/DumpDiscs_LAN/4.png)
-4. Remember your Wii URL (IP address)
-![5](/images/DumpDiscs_LAN/5.png)
-5. On your browser, visit the Wii URL/IP address website given to you.
-![6](/images/DumpDiscs_LAN/6.png)
-6. You should see this. Click on `Click here to download XXXX.iso`
-![7](/images/DumpDiscs_LAN/7.jpg)
-7. The transfer speed is not the fastest, but if you can't use anything else, it's better than nothing.
-
-[I want to dump it directly to my PC over a network](dump-smb)
+[I want to dump it directly to my PC using Wi-Fi or an Ethernet adapter](dump-smb)
 {: .notice--info}

--- a/_pages/en_US/dump-games.md
+++ b/_pages/en_US/dump-games.md
@@ -10,5 +10,5 @@ Please choose how you want to dump the disc.
 [I want to dump it to the SD card/USB device](cleanrip)
 {: .notice--info}
 
-[I want to dump it directly to my PC using Wi-Fi or an Ethernet adapter](dump-smb)
+[I want to dump it directly to my PC over a network](dump-smb)
 {: .notice--info}


### PR DESCRIPTION
we currently have 3 different pages with the same tutorials