### PR TITLE
Add an info box for BootMii Boot2

### DIFF
--- a/_pages/en_US/bootmii.md
+++ b/_pages/en_US/bootmii.md
@@ -15,6 +15,8 @@ One of BootMii's most important features is the ability to backup and restore yo
 * An SD card with at least 512MB of free space
 
 #### Instructions
+If you installed BootMii as Boot2 in the last step, you will need to launch BootMii by restarting the console. Skip steps 1-2 if this is the case. 
+{: .notice--info}
 1. Launch the Homebrew Channel.
 2. Press the HOME Button, then select "Launch BootMii".
    - Navigating BootMii is not possible using a Wii remote. You'd have to either use the buttons on your Wii console or a GameCube controller plugged into port 1.


### PR DESCRIPTION
Currently, the instructions say to launch the Homebrew Channel and click "Launch BootMii". Alot of people get stuck on this step though because if BootMii is installed as Boot2 as recommended in the previous page, this button doesn't show up. The added info box fixes this by instructing anyone who installed it as Boot2 to simply restart the console to access BootMii.