### PR TITLE
Change the invalid notice for vWii theming.

### DIFF
--- a/_pages/en_US/themes.md
+++ b/_pages/en_US/themes.md
@@ -12,7 +12,7 @@ Are you tired of the boring, plain white theme on your Wii Menu, and want a cool
 In the case of a brick, [installing Priiloader is a must](priiloader). Also, install BootMii (as Boot2 if you have an early Wii). Installing brick protection along with following the guide correctly should keep you safe from bricks. DO NOT CONTINUE UNTIL YOU HAVE INSTALLED PRIILOADER AND BOOTMII!
 {: .notice--warning}
 
-Do not install a custom theme on vWii (Wii U)! That will brick it.
+Do not install a custom theme on vWii (Wii U), unless it has been formatted specifically for the vWii and your Wii U's region! Check out [this GBATemp post](https://gbatemp.net/threads/tutorial-installing-custom-themes-in-vwii.476012/) for more on vWii themes.
 {: .notice--warning}
 
 For safety purposes, please do not use any other version of MyMenuify than the one linked here, as MyMenuify Mod is the safest way to install a theme.


### PR DESCRIPTION
The warning will now link to a guide on how to safely inject 4.3 themes into the vWii without using methods done by homebrew apps. The guide also has a tutorial to backup the original vWii theme too in case you brick somehow.