### PR TITLE
Revert SaveGame Manager GX version

### DIFF
--- a/_pages/en_US/wiilink24.md
+++ b/_pages/en_US/wiilink24.md
@@ -4,8 +4,8 @@ title: "WiiLink24"
 
 {% include toc title="Table of Contents" %}
 
-WiiLink24 or any of its services, including Wii no Ma, are not controlled or operated by RiiConnect24 or any of its developers.
-To get support on all issues relating this tutorial and service, join the [WiiLink24 Discord server](https://discord.gg/n4ta3w6)
+WiiLink24 and all of its services (such as Wii no Ma) are not controlled or operated by RiiConnect24.
+To get support on all issues relating this tutorial and service, join the [WiiLink24 Discord server](https://discord.gg/n4ta3w6).
 {: .notice--warning}
 
 [WiiLink24](https://wiilink24.com/) lets you use the Japanese-exclusive Wii no Ma channel, and in the future will let you use the Digicam Print Channel and the Demae Channel again.
@@ -15,7 +15,7 @@ To get support on all issues relating this tutorial and service, join the [WiiLi
 * An SD card or USB drive
 * A Wii with an Internet connection
 * A computer
-* [SaveGame Manager GX](https://static.wiidatabase.de/SaveGame-Manager-GX-Beta.zip)
+* [SaveGame Manager GX](https://static.wiidatabase.de/SaveGame-Manager-GX.zip)
 * [WiiLink24 Patcher (Windows only)](https://github.com/WiiLink24/WiiLink24-Patcher/releases)
 * [Wii no Ma Mii](https://cdn.discordapp.com/attachments/770353472024477727/784849286063718430/Mickey.miigx)
 * [Wii no Ma save file](https://cdn.discordapp.com/attachments/782800044830490664/782800227706732555/WiiRoomSave.bin)
@@ -27,14 +27,14 @@ To get support on all issues relating this tutorial and service, join the [WiiLi
 [If you want to see detailed instructions on how to install the WADs, click here!](wiimodlite)
 {: .notice--info}
 
-1. Download the required files based on your OS. On Windows run `WiiLink24Patcher.bat`.
+1. Download the required files based on your OS. On Windows, run `WiiLink24Patcher.bat`.
 2. Press 1 to choose "`Start`" and confirm your selection by pressing `ENTER`.
 3. For this guide, choose "`Install WiiLink24 on your Wii`"
 4. Select your region.
 5. Connect the SD Card or USB Drive to your computer and select "`1`".
 6. If your device was detected successfully, select "`1`". If not, make sure there's a folder called `apps` on your SD Card or USB Device and try again.
 7. Be patient...
-8. Once it's done, you can now safely close the patcher. All of the files are ready on your SD Card.
+8. Once it's done, you can safely close the patcher. All of the files are ready on your SD Card.
 9. If it did not copy everything automatically to your SD Card or USB Device, copy the `WAD` and `apps` folder next to `WiiLink24Patcher.bat` to your SD Card or USB Device.
 10. Put your SD card or USB drive in your Wii.
 11. Launch the Homebrew Channel on your Wii.


### PR DESCRIPTION
Within Wii no Ma's initial public beta, several regions of Wiis crash or hang prior to creating save data. The latest beta version of SaveGame Manager GX requires a save game already exists for the title before permitting installation. Additionally on some Wiis, regardless of save data existing, the option is not available on the beta.

By using the latest stable version (r127, 2013) which does not include this requirement, these Wiis have a chance of completing installation. Seeing as this workaround will not be required in the future, I feel it is permissible as a temporary workaround.

This additionally includes a few fluency tweaks.