### PR TITLE
Clarify IOS249 System Menu Hack

### DIFF
--- a/_pages/en_US/priiloader.md
+++ b/_pages/en_US/priiloader.md
@@ -77,7 +77,7 @@ This is a list of the hacks you can enable with Priiloader.
 | Remove Diagnostic Disc Check            | Removes a check in the Wii to see if an inserted game is the "Wii Startup Disc".                                             |
 | Lock System Menu with Black Screen      | Makes your Wii Menu load to a black screen, making you unable to use it. (Do not enable this)                                |
 | No-Delete HAXX,JODI,DVDX,DISC,DISK,RZDx | Re-enable channels with these title IDs (originally blocked in system updates due to them being exploits).                   |
-| Force Disc Games to run under IOS249    | Make discs use cIOS 249 as the game's IOS. Can be used to play burned games if there is a cIOS present in that slot          |
+| Force Disc Games to run under IOS249    | Make discs use cIOS 249 as the game's IOS. While it cannot allow playing of burned games on its own, it is needed to play burned discs.          |
 
 
 Continue to installing cIOS<br>


### PR DESCRIPTION
In my testing, I have discovered that this alone will not allow playing burned games. Playing burned games would also require either patching the System Menu IOS or changing the System Menu IOS to a cIOS with Priiloader's System Menu IOS option in settings. Probably can be worded better, this is just to get the point across