### PR TITLE
Shows WiiFlow Lite as an option for a USB Loader

### DIFF
--- a/_pages/en_US/cios.md
+++ b/_pages/en_US/cios.md
@@ -63,5 +63,5 @@ The Homebrew Browser is a good place to get homebrew on your Wii. This is option
 We have many other tutorials that you might like.
 {: .notice--info}
 
-You can now use homebrew such as [USB Loader GX](usbloadergx).
+You can now use homebrew such as [USB Loader GX](usbloadergx)and [WiiFlow Lite](wiiflowlite).
 {: .notice--info}


### PR DESCRIPTION
Shows Wiiflow Lite as a Homebrew that now can be used, and will redirect the user to the page