### PR TITLE
WiiFlow Lite now redirects to wii.guide page

### DIFF
--- a/_pages/en_US/home.md
+++ b/_pages/en_US/home.md
@@ -26,7 +26,7 @@ Here's a list of things you can do with it. While these aren't all the things yo
 
 - Patch game disc contents (allowing you to load game modifications) using [Riivolution](http://www.wiibrew.org/wiki/Riivolution).
 - Install themes to your Wii Menu using [MyMenuify](themes).
-- Install a USB Loader like [WiiFlow Lite](https://gbatemp.net/threads/wiiflow-lite.422685/) or [USB Loader GX](usbloadergx) to launch all your favorite titles from a USB storage device and more.
+- Install a USB Loader like [WiiFlow Lite](wiiflowlite) or [USB Loader GX](usbloadergx) to launch all your favorite titles from a USB storage device and more.
 - Back up your discs with [CleanRip](/dump-games) and installed games and titles with [YABDM](dump-wads)
 - Back up and restore your save files with [SaveGame Manager GX](https://wiidatabase.de/downloads/wii-tools/savegame-manager-gx-beta/)
 - Download new homebrew apps with the [Homebrew Browser](hbb)


### PR DESCRIPTION
WiiFlow Lite now redirects to wii.guide page, not gbatemp.