### PR TITLE
Added Unix Patcher to parts of the guide that said Windows Only

### DIFF
--- a/_pages/en_US/riiconnect24-dolphin.md
+++ b/_pages/en_US/riiconnect24-dolphin.md
@@ -49,7 +49,7 @@ If you choose to run it on startup, you don't have to do anything. If you want t
 
 ##### Section III - Finalizing installation
 
-1. Run RiiConnect24Patcher.bat that you downloaded [here](https://github.com/RiiConnect24/RiiConnect24-Patcher/releases)
+1. On Windows run the `RiiConnect24Patcher.bat` or run the `RiiConnect24Patcher.sh` if you are on a Unix system that you downloaded [here](https://github.com/RiiConnect24/RiiConnect24-Patcher/releases)
 2. Start the patcher, select `Install RiiConnect24`.
 ![Select Custom](/images/Dolphin_RC24/5.jpg)
 3. Select `Custom`.

--- a/_pages/en_US/riiconnect24-vwii.md
+++ b/_pages/en_US/riiconnect24-vwii.md
@@ -27,7 +27,7 @@ Do **NOT** perform this guide on any other console than the vWii (Virtual Wii on
 * A PC or mobile device with internet access and the ability to interact with SD cards.
 * An SD card formatted as FAT32 (at least 2GB) with enough available space. SDHC or SDXC cards formatted as FAT32 can be known to work.
 * A Wii U console capable of launching the Homebrew Launcher (either via the web browser exploit, Haxchi or Coldboot Haxchi). **If you do not have a softmodded Wii U console, please follow [wiiuguide.xyz](https://wiiuguide.xyz), as well as [the virtual Wii modding guide](https://wiiuguide.xyz/#/vwii-modding) and then come back.**
-* [RiiConnect24 Patcher](https://github.com/RiiConnect24/RiiConnect24-Patcher/releases) (Windows only, for now...)
+* [RiiConnect24 Patcher](https://github.com/RiiConnect24/RiiConnect24-Patcher/releases) 
 
 After following the above linked guide, you should have:
 * A vWii NAND backup and keys (keep these stored safely!!)
@@ -38,15 +38,16 @@ After following the above linked guide, you should have:
 
 #### Instructions
 
-If you use GNU/Linux or macOS on your PC, or use a smartphone, please [follow the manual guide](https://pad.snopyta.org/s/rJ2N0B1XU), to install RiiConnect24. The patcher we provide is currently Windows-only. The end result is the same regardless of the method followed.
+If you use cannot use the patcher, please [follow the manual guide](https://pad.snopyta.org/s/rJ2N0B1XU), to install RiiConnect24. The end result is the same regardless of the method followed.
 {: .notice--info}
 
 ##### Section I - Running the patcher
 
 Using the RiiConnect24 Patcher you should've downloaded earlier in [What you need](#what-you-need), you will be downloading and patching IOS31, News, Everybody Votes, Nintendo and Check Mii Out Channels for use on your vWii.
 
-1. Run `RiiConnect24Patcher.bat` on your PC, and follow the on-screen instructions.
-2. Confirm that after running through the patcher, you have 3 folders. They will be in the same folder where `RiiConnect24Patcher.bat` is and on your SD Card (of course, only if you selected an option in the patcher to do so).
+1. Run `RiiConnect24Patcher.bat` on Windows or `RiiConnect24Patcher.sh` on Unix systems by typing bash then drag `RiiConnect24Patcher.sh` into the terminal then press enter. It should look like this `bash RiiConnect24Patcher.sh`. Follow the on screen instructions
+
+2. Confirm that after running through the patcher, you have 3 folders. They will be in the same folder where `RiiConnect24Patcher.bat/sh` is and on your SD Card (of course, only if you selected an option in the patcher to do so).
    - If the patcher did not move the file to the SD Card, move these 3 folders to the root of your SD card.
 
 ##### Section II - Installing the newly patched WADs


### PR DESCRIPTION
The vWii guide and Dolphin guide say Windows Only in front of the RC24 patcher. I took them out as we release the unix patcher yesterday