### PR TITLE
Add str2hax, FlashHax exploits to list of exploits that do not require SD

### DIFF
--- a/_pages/en_US/faq.md
+++ b/_pages/en_US/faq.md
@@ -13,7 +13,7 @@ Either email us at support@riiconnect24.net or join the [RiiConnect24 Discord Se
 ### What are the SD card requirements and/or recommendations?
 You will need an SD card with at least 128MB to run an exploit.
 
-- If you are using the BlueBomb, str2hax, or FlashHax exploit, you do not need an SD card
+- If you are using the BlueBomb, str2hax, or FlashHax exploits, you do not need an SD card
 
 To store homebrew applications, we recommend an SD card with at least 2 GB.
 

--- a/_pages/en_US/faq.md
+++ b/_pages/en_US/faq.md
@@ -13,7 +13,7 @@ Either email us at support@riiconnect24.net or join the [RiiConnect24 Discord Se
 ### What are the SD card requirements and/or recommendations?
 You will need an SD card with at least 128MB to run an exploit.
 
-- If you are using the BlueBomb exploit, you do not need an SD card
+- If you are using the BlueBomb, str2hax, or FlashHax exploit, you do not need an SD card
 
 To store homebrew applications, we recommend an SD card with at least 2 GB.
 


### PR DESCRIPTION
This is a minor change that adds str2hax and FlashHax exploits to the list of exploits that do not require an SD card, since they don't.