### PR TITLE
Update Wiimmfi page with links that don't break with every update

### DIFF
--- a/_pages/en_US/wiimmfi.md
+++ b/_pages/en_US/wiimmfi.md
@@ -45,7 +45,7 @@ MrBean35000vr (creator of CTGP-R, a Mario Kart Wii content pack) created a Wiimm
 
 #### What you need
 * An SD card or USB drive
-* [Auto Wiimmfi Patcher](https://download.wiimmfi.de/patcher/autowiimmfipatcher-0.7.2.zip)
+* [Auto Wiimmfi Patcher](https://download.wiimmfi.de/patcher/autowiimmfipatcher-latest.zip)
 
 #### Instructions
 
@@ -80,7 +80,7 @@ You may not want to run a patcher each time you want to play on Wiimmfi, and may
 - Your copy of your game (WBFS, ISO, cISO, and other forms that a Wii can use are supported).
 - [RiiConnect24 Patcher](https://github.com/RiiConnect24/RiiConnect24-Patcher/releases/) (Windows and Unix)  
    **or**  
-- [Wiimms ISO patcher (cross-platform)](https://download.wiimmfi.de/patcher/wiimmfi-patcher-v7.3.zip)
+- [Wiimms ISO patcher (cross-platform)](https://download.wiimmfi.de/patcher/wiimmfi-patcher-latest.zip)
 - A USB Loader, [cIOS](cios), and a USB to store the game on (you should already have these if you're using a USB Loader)
 
 #### Instructions


### PR DESCRIPTION
In anticipation of yet another Wiimmfi patcher update in the near future, we've configured the Wiimmfi webserver to be able to have version-agnostic links that will always point to the most recent version of the Wiimmfi Patchers, as suggested in #182. 

That should hopefully mean that with more patcher updates the links don't need to be updated every time. 