### PR TITLE
Removed exploit requirement parentheses

### DIFF
--- a/_pages/en_US/get-started.md
+++ b/_pages/en_US/get-started.md
@@ -25,11 +25,11 @@ If you want to install homebrew on a Wii U, [follow this guide](https://wiiu.hac
 These exploits are sorted by easiest to hardest difficulty of use.
 
 - [str2hax](str2hax) - Exploit that uses the Wii EULA
-    * (Requires an Internet connection and changing the DNS server)
+    * Requires an Internet connection and changing the DNS server
 - [LetterBomb](letterbomb) - Exploit that uses the Wii Message Board
-    * (Requires an SD card)
+    * Requires an SD card
 - [FlashHax](flashhax) - Exploit that uses the Internet Channel
-    * (Requires the Internet Channel installed, and an Internet connection)
+    * Requires the Internet Channel installed, and an Internet connection
 - [BlueBomb](bluebomb) - Exploit that uses Bluetooth
     * Requires a computer with Bluetooth and GNU/Linux, as well as a USB storage device
     * This is the only exploit that works on the **Wii mini**


### PR DESCRIPTION
There's already bullet points for them, so the parentheses are not necessary.