### PR TITLE
Adds relevant notices to the BootMii and Priiloader pages

### DIFF
--- a/_pages/en_US/bootmii.md
+++ b/_pages/en_US/bootmii.md
@@ -22,6 +22,8 @@ One of BootMii's most important features is the ability to backup and restore yo
 * An SD card with at least 512MB of free space
 
 #### Instructions
+If you have BootMii installed as boot2 you will need to launch BootMii by restarting the console. Skip steps 1 and 2 if this is the case.
+{: .notice--info}
 1. Launch the Homebrew Channel.
 2. Press the HOME Button, then select "Launch BootMii".
 

--- a/_pages/en_US/priiloader.md
+++ b/_pages/en_US/priiloader.md
@@ -43,6 +43,11 @@ Do **not** install Priiloader on a vWii (Wii mode on Wii U). You will brick your
 2. You should see the Priiloader menu.
 ![Menu](/images/Priiloader/mainmenu.png)
 3. Go to `System Menu Hacks`.
+
+    If you are using a usb to install Priiloader, make sure you do not have an sd card inserted at the same time.
+    This will cause priiloader to be unable to find the hacks_hash.ini file.
+    {: .notice--info}
+
 4. We recommend you turn on the following hacks: `Region Free EVERYTHING`, `Block Disc Updates` and `Block Online Updates`.
 ![System Menu Hacks](/images/Priiloader/hacks.png)
 1. Scroll down to `save settings` and press A, then press B to go back to the main menu of Priiloader.


### PR DESCRIPTION
This is a redo of #206; most of the info is the same.

This PR adds 2 notices:

1. BootMii - Re-adds a previous notice about running BootMii if installed only as Boot2
2. Priiloader - Adds a notice about `hacks_hash.ini` in the case that it isn't properly detected by Priiloader due to an sd card being inserted with the file on a usb.

These notices would be helpful to people using the guide, and would solve issues I've seen come up when helping others with homebrew.