### PR TITLE
Add Citra and Cemu to the RiiTag page

### DIFF
--- a/_pages/en_US/riitag.md
+++ b/_pages/en_US/riitag.md
@@ -59,8 +59,9 @@ The steps to connect RiiTag to your USB Loader depend on what USB Loader you use
 7. Save the modified `wiiflow.ini` file.
 8. You have now set up RiiTag. You can try loading any game now to see if it works correctly.
 
-###### Dolphin
+###### Emulators
 
+RiiTag supports Dolphin, Citra, and Cemu.
 You need a Discord account for this to work.
 {: .notice--info}
 


### PR DESCRIPTION
With the recent addition of RPC game loading for Citra and Cemu in RiiTag this page should be updated from just Dolphin.