### PR TITLE
Added note about FAT32 and MBR

### DIFF
--- a/_pages/en_US/letterbomb.md
+++ b/_pages/en_US/letterbomb.md
@@ -10,7 +10,7 @@ If you need help for anything regarding this tutorial, please join [the RiiConne
 LetterBomb is an exploit for the Wii that is triggered using the Wii Message Board.
 
 #### What you need
-- An SD card
+- An SD card formatted as FAT32 with MBR partition tables
 - A Wii on System Menu version 4.3
 
 #### Instructions


### PR DESCRIPTION
The SD card used must have MBR partition tables and be formatted as FAT32, otherwise the letter will not appear.