### PR TITLE
Add warning about video guides and their unusually large chance of irriversibly bricking a wii mini

### DIFF
--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -4,6 +4,9 @@ title: "BlueBomb"
 
 {% include toc title="Table of Contents" %}
 
+It is strongly advised against using **any** video guide for hacking your Wii mini console, as there is an extremely large chance of bricking it.
+{: .notice-warning}
+
 If you need help with anything regarding this tutorial, please join [the Wii mini Hacking Discord server](https://discord.gg/6ryxnkS) (recommended)
 {: .notice--info}
 


### PR DESCRIPTION
Honestly we've had like at least 9-10 irreversible bricks due to people installing Wii cios or random Wii IOSes in the past few months and we're all starting to get pretty frustrated so I'm adding this here as an extra big red box people should hopefully see.