### PR TITLE
Add wii mini IOS and bootmini warnings

### DIFF
--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -34,7 +34,7 @@ For the original Wii, we do not recommend using BlueBomb if you intend to instal
 #### Section II - Performing the exploit
 1. Download the HackMii installer from [the BootMii website](https://bootmii.org/download/).
 - (If attempting to fix a brick, you should also copy the homebrew app you wish to use to /apps/)
-1. Extract it and place the `boot.elf` file in your flash drive.
+1. Extract it and place the `boot.elf` file in your flash drive. (Even for a Wii mini, bootmini.elf will **not** work, its purpose is entirely different and unrelated).
 1. Connect the flash drive to the console. For a Wii mini, the USB port is on the back. For a normal Wii, use the bottom port. (or the right port if it's upright).
 1. Turn on your console and navigate to the settings menu. On the top right corner you will see a 4-character code like the one in the picture below. This code is your Wii Menu version, take a note of this as you will need it later. Afterwards, turn your console off.
 ![SystemMenuVersion](/images/Wii/SystemMenuVersion.png)

--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -34,7 +34,8 @@ For the original Wii, we do not recommend using BlueBomb if you intend to instal
 #### Section II - Performing the exploit
 1. Download the HackMii installer from [the BootMii website](https://bootmii.org/download/).
 - (If attempting to fix a brick, you should also copy the homebrew app you wish to use to /apps/)
-1. Extract it and place the `boot.elf` file in your flash drive. (Even for a Wii mini, bootmini.elf will **not** work, its purpose is entirely different and unrelated).
+1. Extract it and place the `boot.elf` file in your flash drive. 
+- (Even for a Wii mini, bootmini.elf will **not** work, its purpose is entirely different and unrelated).
 1. Connect the flash drive to the console. For a Wii mini, the USB port is on the back. For a normal Wii, use the bottom port. (or the right port if it's upright).
 1. Turn on your console and navigate to the settings menu. On the top right corner you will see a 4-character code like the one in the picture below. This code is your Wii Menu version, take a note of this as you will need it later. Afterwards, turn your console off.
 ![SystemMenuVersion](/images/Wii/SystemMenuVersion.png)

--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -35,7 +35,7 @@ For the original Wii, we do not recommend using BlueBomb if you intend to instal
 1. Download the HackMii installer from [the BootMii website](https://bootmii.org/download/).
 - (If attempting to fix a brick, you should also copy the homebrew app you wish to use to /apps/)
 1. Extract it and place the `boot.elf` file in your flash drive. 
-- (Even for a Wii mini, bootmini.elf will **not** work, its purpose is entirely different and unrelated).
+- (Even for a Wii mini, bootmini.elf will **not** work, its purpose is entirely different and unrelated. Use boot.elf in all cases).
 1. Connect the flash drive to the console. For a Wii mini, the USB port is on the back. For a normal Wii, use the bottom port. (or the right port if it's upright).
 1. Turn on your console and navigate to the settings menu. On the top right corner you will see a 4-character code like the one in the picture below. This code is your Wii Menu version, take a note of this as you will need it later. Afterwards, turn your console off.
 ![SystemMenuVersion](/images/Wii/SystemMenuVersion.png)

--- a/_pages/en_US/dosanddonts.md
+++ b/_pages/en_US/dosanddonts.md
@@ -18,6 +18,7 @@ Here's a list of things you should and should not do once you've modded your Wii
 - **DO NOT** or use old versions of Wii homebrew. If you follow Wii modding tutorials from the Internet, be cautious about using old tutorials (likely pre-2012), especially if they have to do with things such as IOS.
 - **DO NOT** modify, rename, or delete random files on your Wii NAND unless you know what you are doing.
 - **DO NOT** use the homebrew app "KoreanKii" on a non-Korean Wii.
+- **DO NOT** Install **any** IOS or Wii System Menu on a Wii mini other than [d2xl cIOS](/cios-mini). Doing so **will** brick your console if a Wifi card is not soldered to it.
 - **DO NOT** use any Nintendo Wi-Fi Connection replacement on your Wii except for [Wiimmfi](/wiimmfi). Unfortunately, other replacement servers are vulnerable to an exploit that can brick your Wii if you use them. [RiiConnect24](/riiconnect24) is safe to use as well.
 
 If you follow these guidelines, you won't have to worry about bricking your Wii. Wii modding is safe, and bricks usually occur due to something done by the user that is on this list.


### PR DESCRIPTION
Sometimes I just don't understand people. Today someone came in the Wii mini discord and said that bluebomb was failing to jump to entrypoint. I asked whether they put boot.elf in their flash drive and they said "Yes, it was failing as bootmini.elf so I renamed it". Anyway, so there's that now. If you need me for anything I'll be next to my desk banging my head against the wall.