### PR TITLE
Notes about region selection and SD adapters

### DIFF
--- a/_pages/en_US/letterbomb.md
+++ b/_pages/en_US/letterbomb.md
@@ -18,15 +18,18 @@ LetterBomb is an exploit for the Wii that is triggered using the Wii Message Boa
 
 1. On your Wii, go to `Wii Settings` -> `Internet` -> `Console Information` and make note of your MAC address.
 1. Visit [please.hackmii.com](https://please.hackmii.com), input your Wii MAC and region, complete the CAPTCHA, ensure `Bundle the HackMii Installer for me!` is checked, and cut either wire
+   - By default, the selected region is 4.3E (Europe), so if you are in a different region, you will have to select the correct one.
    - Whichever wire you choose to cut doesn't matter.
 ![HackMii Screen](/images/Wii/LetterBomb-PC.png)
 1. Extract the contents of the downloaded ZIP to the root of your SD card.
 1. Take out your SD card and insert it in your Wii.
+   - The SD card must be inserted in the SD card slot located in the front of the Wii. Using a USB adapter plugged into the Wii's USB port will not work.
 1. On your Wii, return to the Wii Menu and then open the Wii Message Board.
 1. Load the red letter with a bomb icon.
    - Ensure the date on your Wii is correct, otherwise you might be unable to find the letter.
    - In various scenarios, you may need to look at the previous or next day to find it.
    - If you don't see the red letter, you may be using an unsupported SD card that's greater than 32GB in size.
+   - If your Wii freezes after clicking on the letter, you probably chose the wrong region when downloading the exploit. Redo Step 2 and select the correct region.
 
 
 {: .notice--warning}


### PR DESCRIPTION
Ever since GeoIP broke for the Letterbomb site, 4.3E has been the region selected by default, and users have been thrown off by this. So I added an extra note explaining this and confirming that the user has chosen the proper region. Also added a note to step 6 about what could happen if the incorrect region is selected.

Believe it or not, some users have had issues with Letterbomb because they thought a USB-SD adapter plugged into the Wii would still work. So added a note about that to step 4.