### PR TITLE
Fix license marker in readme linking to AGPLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-## Wii Guide
-[![License](https://img.shields.io/github/license/riiconnect24/wii-guide.svg?style=flat-square)](http://www.gnu.org/licenses/agpl-3.0)
+# Wii Guide
+
+[![License](https://img.shields.io/github/license/riiconnect24/wii-guide.svg?style=flat-square)](LICENSE.txt)
 ![Production List](https://img.shields.io/discord/206934458954153984.svg?style=flat-square)
 
 Wii.guide is the complete guide to modding your Nintendo Wii console.
@@ -7,6 +8,7 @@ We're here to help people installing Homebrew Channel and many other mods to the
 
 The site: [wii.guide](https://wii.guide)
 
-# Would you like to contribute?
+## Would you like to contribute?
+
 You can translate the site by using Crowdin, a site created to translate projects.
 You can join here: [Wii.guide's Crowdin Page](https://crowdin.com/project/wii-guide)


### PR DESCRIPTION
Simply fixes the license marker in the readme to not link to the AGPLv3 (since this is MIT licensed), instead linking directly to the [LICENSE.txt](LICENSE.txt) file. Also swaps out the headings to be [MD022](https://github.com/DavidAnson/markdownlint/blob/v0.25.1/doc/Rules.md#md022) and [MD401](https://github.com/DavidAnson/markdownlint/blob/v0.25.1/doc/Rules.md#md041) compliant.