### PR TITLE
Add note about the unix screenshots in Dolphin

### DIFF
--- a/_pages/en_US/riiconnect24-dolphin.md
+++ b/_pages/en_US/riiconnect24-dolphin.md
@@ -63,6 +63,9 @@ If you choose to run it on startup, you don't have to do anything. If you want t
 </div>
 
 <div id="unix" class="blanktabcontent" markdown="1">
+The screenshots in this section are taken from Windows, but the same steps can be followed on your Unix-based machine.
+{: .notice--info}
+
 1. Run `VFF-Downloader-for-Dolphin.sh`.
 ![Main Menu](/images/Dolphin_RC24/2.jpg)
 3. Proceed with the program configuration.


### PR DESCRIPTION
Since the screenshots in the Unix section are the old ones, which are taken from the Windows command prompt, I thought I'd add a note about that. I plan to replace these, but I either need to fire up WSL or something, or fire up my Ubuntu machine :P