### PR TITLE
Download IOS58 from NUS via NUS Downloader in the update guide

### DIFF
--- a/_pages/en_US/update.md
+++ b/_pages/en_US/update.md
@@ -10,9 +10,9 @@ If you need help for anything regarding this tutorial, please join [the RiiConne
 This tutorial will explain how to update your Wii Menu to version 4.3, if you have already homebrewed your Wii.
 
 #### What you need
+
 * An SD card or USB drive
 * A computer with Windows on it
-* [IOS58 Installer](https://oscwii.org/library/app/ios58-installer)
 * [NUS Downloader](https://github.com/WiiDatabase/nusdownloader/releases/latest)
 * [Wii Mod Lite](https://oscwii.org/library/app/WiiModLite)
 
@@ -34,14 +34,15 @@ To protect against bricks, [make sure you install Priiloader](priiloader). Also,
 3. Make sure `Pack WAD` is checked.
 4. Press `Start NUS Download!`.
 5. Open the `titles` -> `0000000100000002` -> (Wii Menu version) and copy the .wad file to a folder called `wad` on your SD Card or USB drive.
-6. (If you have [RiiConnect24](riiconnect24), you can skip this step) Repeat steps 2-5 with `IOS` -> `0000000100000050 - IOS80` -> `Latest Version`.
+6. Repeat steps 2-5 with `IOS` -> `000000010000003A` -> `Latest Version`.
+7. (If you have [RiiConnect24](riiconnect24), you can skip this step) Repeat steps 2-5 with `IOS` -> `0000000100000050 - IOS80` -> `Latest Version`.
 
 | Region | Wii Menu version                                                               |
 | ------ | ---------------------------------------- |
 | Japan  | v512 (4.3J) |
-| USA    |  v513 (4.3U)   |
-| Europe |    v514 (4.3E)    |
-| Korea |    v518 (4.3K)    |
+| USA    | v513 (4.3U) |
+| Europe | v514 (4.3E) |
+| Korea  | v518 (4.3K) |
 
 ##### Section II - Installing
 
@@ -52,11 +53,10 @@ You use the +Control Pad to use this tool.
 2. Launch the Homebrew Channel on your Wii.
 3. Launch Wii Mod Lite.
 4. Using the +Control Pad on your Wii Remote, navigate to `WAD Manager`, and then navigate to the `wad` folder.
-5. Press A to install the IOS80. [`Make sure the installation is successful, otherwise abort.`]
+5. Press A to install the IOS80 `.wad` file. [`Make sure the installation is successful, otherwise abort.`]
 6. Press A to install the Wii Menu WAD.
-7. After they are successfully installed, press the HOME Button to exit back to the Homebrew Channel.
-8. Launch IOS58 Installer.
-9. Follow the instructions to install IOS58.
+7. Press A to install the IOS58 `.wad` file. [`Make sure the installation is successful, otherwise abort.`]
+8. After they are successfully installed, press the HOME Button to exit back to the Homebrew Channel.
 
 Installing a Wii Menu WAD will **remove** Priiloader. Do not reboot before you have installed it again, otherwise you could BRICK.
 {: .notice--danger}


### PR DESCRIPTION
This is a change requested on Discord [message](https://discord.com/channels/206934458954153984/288361557044494337/1010342324976492634) ([via](https://discord.gg/rc24)). The reason for this change is including using IOS58 Installer just adds one extra step when you were already downloading stuff from NUS anyway and installing it with Wii Mod Lite, you may as well get IOS58 from there as well, saves a step.