### PR TITLE
Added a small but necessary instruction in str2hax

### DIFF
--- a/_pages/en_US/str2hax.md
+++ b/_pages/en_US/str2hax.md
@@ -49,7 +49,7 @@ This exploit requires you to set your DNS in order to connect to a server that c
 ##### Section II - Triggering the Exploit
 
 1. Go to the `Internet` section, then `User Agreements` or `Agreement/Contact`, then `Yes`.
-2. If you see a pony on the screen on a light blue background, you have set it up correctly. Wait 1-2 minutes for the exploit to trigger (it should take about 1 minute and 25 seconds). The exploit will download the HackMii Installer so you can continue.
+2. Click on `Next` and then if you see a pony on the screen on a light blue background, you have set it up correctly. Wait 1-2 minutes for the exploit to trigger (it should take about 1 minute and 25 seconds). The exploit will download the HackMii Installer so you can continue.
 
 If the HackMii Installer doesn't load and it instead freezes (you can't move your cursor) or it doesn't take 1-2 minutes to trigger, please restart your Wii and retry the exploit.
 


### PR DESCRIPTION
In the current state, the guide doesn't specify that you have to press 'Next' before seeing the pony on the subsequent screen. The users may end up waiting on the screen where they are supposed to press next thinking their DNS configuration or something else went wrong. This should help.