### PR TITLE
fix: typos  `throughly` and `unneccessary`

### DIFF
--- a/_pages/en_US/gcbackupmanager.md
+++ b/_pages/en_US/gcbackupmanager.md
@@ -34,7 +34,7 @@ Make sure your USB drive is formatted as FAT32. Do not format it as other types 
 3. Click on the `Files (Destination)` tab, then select the `Inactive` option from the dropdown menu. This will allow you to choose the drive where you want to transfer the game. Select the appropriate drive letter from the list.
 4. Next, go back to the `Files (Source)` tab, select the game you want to transfer, and then click either `Install Game (1:1)` or `Install Game (Scrub)`.
 
-Selecting `Install Game (Scrub)` will remove unneccessary data from the game, reducing the game's file size.
+Selecting `Install Game (Scrub)` will remove unnecessary data from the game, reducing the game's file size.
 {: .notice--info}
 
 [Continue to site navigation](site-navigation)<br>

--- a/_pages/en_US/wiilink-demae-dominos.md
+++ b/_pages/en_US/wiilink-demae-dominos.md
@@ -97,7 +97,7 @@ If you have previously placed an order, skip to step 4.
 4. Click the `Pizza` button. This will load all the restaurants in your area. The first restaurant in the list is the one closest to you.
 5. Click `See Menu` to list the different menu categories. Click the category you would like, then select a food item. In the item screen, you can add toppings and adjust quantity.
 6. After adding a food item, you will be brought to the basket. To add a food item, scroll to the bottom and select `Add Order`. To proceed to checkout, click `Next`.
-7. Review your order throughly before placing the order. When you are ready, click the big green `Order` button.<br><br>
+7. Review your order thoroughly before placing the order. When you are ready, click the big green `Order` button.<br><br>
    ![Before Order](/images/Demae-Dominos/order.png)<br><br>
 8. If no error appeared, your order was placed successfully! To track your order, simply visit the Domino's Tracker for your region and enter the phone number you entered in the Address Information menu.
 


### PR DESCRIPTION
The typos `throughly` and `unneccessary` were found by [typos](https://github.com/crate-ci/typos):

```
error: `throughly` should be `thoroughly`
  --> .\wiilink-demae-dominos.md:100:22
    |
100 | 7. Review your order throughly before placing the order. When you are ready, click the big green `Order` button.<br><br>
    |                      ^^^^^^^^^
    |
error: `unneccessary` should be `unnecessary`
  --> .\gcbackupmanager.md:37:46
   |
37 | Selecting `Install Game (Scrub)` will remove unneccessary data from the game, reducing the game's file size.
   |                                              ^^^^^^^^^^^^
   |
```