### PR TITLE
Update the Sharpii Download Path in d2x_offline_cios.sh

### DIFF
--- a/assets/files/d2x_offline_ios.sh
+++ b/assets/files/d2x_offline_ios.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-Sharpii_DL="https://noahpistilli.github.io/RC24_Patcher/Sharpii"
+Sharpii_DL="https://patcher.rc24.xyz/update/RiiConnect24-Patcher_Unix/v1/Sharpii"
 
 epicfail () {
 	printf "


### PR DESCRIPTION
This updates the Sharpii download path to the one currently used by the RC24 Unix patcher, as the current download link is dead (Github Pages 404)